### PR TITLE
Display an image preview when uploading an image to a story

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,0 +1,24 @@
+function showImage(input) {
+  if (input.files && input.files[0]) {
+    var reader = new FileReader()
+    reader.onload = function (e) {
+      $('#image_preview')
+        .attr('src', e.target.result);
+      $('#image_thumbnail_preview')
+        .attr('src', e.target.result);
+
+      $('#image_preview_wrapper')
+        .removeClass('hide');
+      $('#image_thumbnail_preview_wrapper')
+        .removeClass('hide');
+    }
+    reader.readAsDataURL(input.files[0]);
+  }
+}
+
+$("document").ready(function(){
+
+  $('#image_upload').on('change', function() {
+    showImage(this);
+  })
+})

--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -1,7 +1,9 @@
-// A little hacky, sorry!  Change this if you ever change the order of the form fields
-// It should target the WYSIWYG editor to make it full width on failed validations
 .wysiwyg {
   .field_with_errors {
     width: 100%;
   }
+}
+
+.hide {
+  display: none;
 }

--- a/app/views/stories/_form.haml
+++ b/app/views/stories/_form.haml
@@ -19,21 +19,21 @@
       = f.text_area :text, value: @story.text, :class => "tinymce", style: "height: 500px;"
     .field
       = f.label 'Photo'
-      = f.file_field :photo
+      = f.file_field :photo, id: "image_upload"
     .actions
       = f.submit 'Save'
 
-  - if !@story.image.blank?
-    %br
-    %div
-      %p Image Preview:
-      =image_tag @story.image, width: '400'
+    %div{ id: "image_preview_wrapper", :class => ("hide" if @story.image.blank?) }
+      %br
+      %div
+        %p Image Preview:
+        =image_tag @story.image, id: "image_preview", width: '400'
 
-  - if !@story.image_thumbnail.blank?
-    %br
-    %div
-      %p Thumbnail Preview:
-      =image_tag @story.image_thumbnail, width: '400'
+    %div{ id: "image_thumbnail_preview_wrapper", :class => ("hide" if @story.image_thumbnail.blank?) }
+      %br
+      %div
+        %p Thumbnail Preview:
+        =image_tag @story.image_thumbnail, id: "image_thumbnail_preview", width: '200'
 
   %br
   = tinymce


### PR DESCRIPTION
Test steps:

1. Go to a story add/edit page without an existing image.
2. Verify no image preview appears at the bottom of the page.
3. Upload an image (but don't save).
4. Verify an image preview appears.
5. Verify saving works.
6. Go to a story add/edit page with an existing image.
7. Verify an image preview appears at the bottom of the page.
8. Upload an image (but don't save).
9. Verify the image preview changes.
10. Verify saving works.
11. Go to a new story add/edit page and upload an image.
12. Delete the title/body text and try to save (it should fail validation).
13. Verify that the image didn't upload to S3 but still exists on the page when the validation failure re-renders the page to show errors.